### PR TITLE
Update to Crystal 1.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,8 @@
 name: bloom_filter
 version: 0.1.0
 
+crystal: 1.9.2
+
 authors:
   - Potapov Sergey <blake131313@gmail.com>
 


### PR DESCRIPTION
~Also turn the `@bitmap` into `Bytes` instead of Array, since it's more efficient. And also pop the size of the bitmap in the serialised version, so we can immediately allocate the size of the slice when deserialising.~

Byte-stuff will be done in another PR, this is just Crystal 1.0 compatibility.